### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,10 @@ const isPlainObject = function (value) {
   return !!value && typeof value === 'object' && value.constructor === Object
 }
 
+const isPrototypePolluted = function (key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
+}
+
 const mkdirP = function (object, path) {
   if (!path) {
     return object
@@ -446,6 +450,7 @@ const utils = {
   deepMixIn (dest, source) {
     if (source) {
       for (var key in source) {
+        if (isPrototypePolluted(key)) continue
         const value = source[key]
         const existing = dest[key]
         if (isPlainObject(value) && isPlainObject(existing)) {

--- a/test/unit/utils/extendUtils.test.js
+++ b/test/unit/utils/extendUtils.test.js
@@ -54,6 +54,14 @@ describe('utils.deepMixIn', function () {
     assert.deepEqual(expected, actual, 'sorce own properties recursivly copied and overriden into dest')
     assert.equal(dest, utils.deepMixIn(dest), 'empty source argument returns dest')
   })
+  
+  it('should not pollute prototype', function () {
+    const dest = {}
+    const src = JSON.parse('{"__proto__": {"polluted": true}}')
+    utils.deepMixIn(dest, src)
+
+    assert.equal({}.polluted, undefined, 'object prototype is polluted')
+  })
 })
 
 describe('utils.extend', function () {


### PR DESCRIPTION
### :bar_chart: Metadata *

`js-data` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-js-data

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const js = require("js-data");
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
js.utils.deepMixIn(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i js-data # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![js-data-fix](https://user-images.githubusercontent.com/43996156/102888980-caddc900-447f-11eb-99cc-a7764d285993.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
