### PR TITLE
Prototype pollution fix - checking magic attributes - js-data

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,10 @@ const mkdirP = function (object, path) {
   return object
 }
 
+const isPrototypePolluted = function (key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key)
+}
+
 const utils = {
   /**
    * Reference to the Promise constructor used by JSData. Defaults to
@@ -446,6 +450,7 @@ const utils = {
   deepMixIn (dest, source) {
     if (source) {
       for (var key in source) {
+        if (isPrototypePolluted(key)) continue
         const value = source[key]
         const existing = dest[key]
         if (isPlainObject(value) && isPlainObject(existing)) {

--- a/test/unit/utils/extendUtils.test.js
+++ b/test/unit/utils/extendUtils.test.js
@@ -54,6 +54,15 @@ describe('utils.deepMixIn', function () {
     assert.deepEqual(expected, actual, 'sorce own properties recursivly copied and overriden into dest')
     assert.equal(dest, utils.deepMixIn(dest), 'empty source argument returns dest')
   })
+
+  it('Recursively shallow copies properties from `source` to `dest`', function () {
+    const dest = {}
+    const src = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}')
+    utils.deepMixIn(dest, src)
+
+    assert.equal(dest.polluted, undefined, 'dest must not overwrite prototype constructor')
+    assert.equal({}.polluted, undefined, 'must prevent prototypical inherited values')
+  })
 })
 
 describe('utils.extend', function () {


### PR DESCRIPTION
### 📊 Metadata *

js-data is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-js-data/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
const js = require("js-data");
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
js.utils.deepMixIn(obj, payload);
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i js-data # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/104737710-9e5d5a00-576a-11eb-980d-751cab4eaf40.png)

After:
![image](https://user-images.githubusercontent.com/64132745/104738037-04e27800-576b-11eb-94e0-b93dfacf19f0.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104739858-3c522400-576d-11eb-85c3-ab515c41ebfa.png)

After applying the fix, functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-js-data/